### PR TITLE
Added support for installer authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is not affiliated with Kostal and is no offical product. It uses th
 
 ### Prerequisites
 
-You will need Python >=3.7.py
+You will need Python >=3.7.
 
 ### Installing the library
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is not affiliated with Kostal and is no offical product. It uses th
 
 ### Prerequisites
 
-You will need Python >=3.7.
+You will need Python >=3.7.py
 
 ### Installing the library
 
@@ -109,6 +109,13 @@ home_p = device_local['Home_P']
 
 See the full example here: [read_process_data.py](examples/read_process_data.py).
 
+If you should need installer access use the master key (printed on a label at the side of the inverter) 
+and additionally pass your service code:
+
+```python
+await client.login(my_master_key, service_code=my_service_code)
+```
+
 
 ## Documentation
 
@@ -129,3 +136,4 @@ apache-2.0
 
 
 * [kilianknoll](https://github.com/kilianknoll) for the kostal-RESTAPI project 
+ 

--- a/pykoplenti/__init__.py
+++ b/pykoplenti/__init__.py
@@ -405,7 +405,7 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
     async def login(self,
                     key: str,
                     service_code: Union[str, None] = None):
-        """Login with the given password (key). If not service code is provided, user is 'user'.
+        """Login with the given password (key). If a service code is provided user is 'master', else 'user'.
 
         Parameters
         ----------

--- a/pykoplenti/__init__.py
+++ b/pykoplenti/__init__.py
@@ -379,7 +379,8 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
         self.host = host
         self.port = port
         self.session_id = None
-        self._password = None
+        self._key = None
+        self._service_code = None
         self._user = None
 
     async def __aexit__(self, exc_type, exc_value, traceback):
@@ -401,22 +402,32 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
         )
         return base.join(URL(path))
 
-    async def login(self, password: str, user: str = "user"):
-        """Login the given user (default is 'user') with the given
-        password.
+    async def login(self,
+                    key: str,
+                    service_code: Union[str, None] = None):
+        """Login with the given password (key). If not service code is provided, user is 'user'.
+
+        Parameters
+        ----------
+        :param key: The user password. If 'service_code' is given, 'key' is the Master Key (also called Device ID).
+        :type key: str, None
+        :param service_code: Installer service code. If given the user is assumed to be 'master', else 'user'.
+        :type service_code: str, None
 
         :raises AuthenticationException: if authentication failed
         :raises aiohttp.client_exceptions.ClientConnectorError: if host is not reachable
         :raises asyncio.exceptions.TimeoutError: if a timeout occurs
         """
 
-        self._password = password
-        self._user = user
+        self._key = key
+        self._user = 'master' if service_code else 'user'
+        self._service_code = service_code
         try:
             await self._login()
         except Exception:
-            self._password = None
+            self._key = None
             self._user = None
+            self._service_code = None
             raise
 
     async def _login(self):
@@ -440,7 +451,7 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
 
         # Step 2 finish authentication (RFC5802)
         salted_passwd = hashlib.pbkdf2_hmac(
-            "sha256", self._password.encode("utf-8"), salt, rounds
+            "sha256", self._key.encode("utf-8"), salt, rounds
         )
         client_key = hmac.new(
             salted_passwd, "Client Key".encode("utf-8"), hashlib.sha256
@@ -490,6 +501,10 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
         protocol_key = session_key_hmac.digest()
         session_nonce = urandom(16)
         cipher = AES.new(protocol_key, AES.MODE_GCM, nonce=session_nonce)
+
+        if self._user == 'master':
+            token = f"{token}:{self._service_code}"
+
         cipher_text, auth_tag = cipher.encrypt_and_digest(token.encode("utf-8"))
 
         session_request = {
@@ -573,7 +588,8 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
 
     async def logout(self):
         """Logs the current user out."""
-        self._password = None
+        self._key = None
+        self._service_code = None
         async with self._session_request("auth/logout", method="POST") as resp:
             await self._check_response(resp)
 


### PR DESCRIPTION
Great project, thank you for your effort! 

For the automated configuration of inverters I thought a support for installer login would be helpful and extended the code of the lib respectively. I didn't touch the CLI though.  Also I removed configuring the user name. There doesn't seem to be a choice. It is 'master' for installers and 'user' else.