### PR TITLE
Fix format string for read events cli command.

### DIFF
--- a/pykoplenti/cli.py
+++ b/pykoplenti/cli.py
@@ -236,7 +236,7 @@ def read_events(global_args, lang, count):
         for event in data:
             print(
                 f"{event.is_active < 5} {event.start_time} {event.end_time} "
-                "{event.description}"
+                f"{event.description}"
             )
 
     asyncio.run(


### PR DESCRIPTION
Fix for #15

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the format string in the CLI command for reading events to ensure the event description is correctly displayed.

Bug Fixes:
- Correct the format string in the CLI command for reading events to properly interpolate the event description.

<!-- Generated by sourcery-ai[bot]: end summary -->