### PR TITLE
Fixed Compatiblity Issues with Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
         run: |
           pipenv run build
       - name: Upload packages to github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.egg-info
 build/
 dist/
+.tox/
 pip-wheel-metadata/
 .env.local
 coverage.xml

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -25,8 +25,17 @@ tox
 
 Available environments:
 
+* `py39-pydantic1` - Python 3.9 with Pydantic 1.x
+* `py39-pydantic2` - Python 3.9 with Pydantic 2.x
 * `py310-pydantic1` - Python 3.10 with Pydantic 1.x
 * `py310-pydantic2` - Python 3.10 with Pydantic 2.x
+* `py311-pydantic1` - Python 3.11 with Pydantic 1.x
+* `py311-pydantic2` - Python 3.11 with Pydantic 2.x
+* `py312-pydantic1` - Python 3.12 with Pydantic 1.x
+* `py312-pydantic2` - Python 3.12 with Pydantic 2.x
+
+If `tox` should use `pyenv`, the package `tox-pyenv-redux` must be installed manually.
+It cannot be installed in pipenv dev, because it is incompatible with github actions.
 
 ## Running smoke tests
 

--- a/pykoplenti/model.py
+++ b/pykoplenti/model.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Final, Iterator, Mapping
+from typing import Final, Iterator, Mapping, Optional
 
 import pydantic
 from pydantic import BaseModel, Field
@@ -78,11 +78,11 @@ class ProcessDataCollection(Mapping):
 class SettingsData(BaseModel):
     """Represents a single settings data."""
 
-    min: str | None
-    max: str | None
-    default: str | None
+    min: Optional[str]
+    max: Optional[str]
+    default: Optional[str]
     access: str
-    unit: str | None
+    unit: Optional[str]
     id: str
     type: str
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,10 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries
 
 [options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, Callable, Union
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import ClientResponse, ClientSession
@@ -30,7 +30,7 @@ def client_response_factory(
 ) -> Callable[[int, Any], MagicMock]:
     """Provides a factory to add responses to a ClientSession."""
 
-    def factory(status: int = 200, json: list[Any] | dict[Any, Any] | None = None):
+    def factory(status: int = 200, json: Union[list[Any], dict[Any, Any], None] = None):
         response = MagicMock(spec_set=ClientResponse, name="request Mock")
         response.status = status
         if json is not None:

--- a/tests/test_extendedapiclient.py
+++ b/tests/test_extendedapiclient.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Union
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
@@ -40,7 +40,9 @@ class TestVirtualProcessDataValuesDcSum:
     async def test_virtual_process_data(
         self,
         pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-        client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+        client_response_factory: Callable[
+            [int, Union[list[Any], dict[Any, Any]]], MagicMock
+        ],
         websession: MagicMock,
     ):
         """Test virtual process data for PV power if depencies are present."""
@@ -70,7 +72,9 @@ class TestVirtualProcessDataValuesDcSum:
     async def test_virtual_process_data_value(
         self,
         pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-        client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+        client_response_factory: Callable[
+            [int, Union[list[Any], dict[Any, Any]]], MagicMock
+        ],
         websession: MagicMock,
     ):
         """Test virtual process data for PV power."""
@@ -142,7 +146,9 @@ class TestVirtualProcessDataValuesEnergyToGrid:
     async def test_virtual_process_data(
         self,
         pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-        client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+        client_response_factory: Callable[
+            [int, Union[list[Any], dict[Any, Any]]], MagicMock
+        ],
         websession: MagicMock,
         scope: str,
     ):
@@ -183,7 +189,9 @@ class TestVirtualProcessDataValuesEnergyToGrid:
     async def test_virtual_process_data_value(
         self,
         pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-        client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+        client_response_factory: Callable[
+            [int, Union[list[Any], dict[Any, Any]]], MagicMock
+        ],
         websession: MagicMock,
         scope: str,
     ):
@@ -269,10 +277,12 @@ class TestVirtualProcessDataValuesEnergyToGrid:
 @pytest.mark.asyncio
 async def test_virtual_process_data_no_dc_sum(
     pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-    client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+    client_response_factory: Callable[
+        [int, Union[list[Any], dict[Any, Any]]], MagicMock
+    ],
     websession: MagicMock,
 ):
-    """Test if no virtual process data is present if dependecies are missing."""
+    """Test if no virtual process data is present if dependencies are missing."""
     client_response_factory(
         200,
         [
@@ -297,7 +307,9 @@ async def test_virtual_process_data_no_dc_sum(
 @pytest.mark.asyncio
 async def test_virtual_process_data_and_normal_process_data(
     pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-    client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+    client_response_factory: Callable[
+        [int, Union[list[Any], dict[Any, Any]]], MagicMock
+    ],
     websession: MagicMock,
 ):
     """Test if virtual and non-virtual process values can be requested."""
@@ -362,7 +374,9 @@ async def test_virtual_process_data_and_normal_process_data(
 @pytest.mark.asyncio
 async def test_virtual_process_data_not_all_requested(
     pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-    client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+    client_response_factory: Callable[
+        [int, Union[list[Any], dict[Any, Any]]], MagicMock
+    ],
     websession: MagicMock,
 ):
     """Test if not all available virtual process data are requested."""
@@ -429,7 +443,9 @@ async def test_virtual_process_data_not_all_requested(
 @pytest.mark.asyncio
 async def test_virtual_process_data_multiple_requested(
     pykoplenti_extended_client: pykoplenti.ExtendedApiClient,
-    client_response_factory: Callable[[int, list[Any] | dict[Any, Any]], MagicMock],
+    client_response_factory: Callable[
+        [int, Union[list[Any], dict[Any, Any]]], MagicMock
+    ],
     websession: MagicMock,
 ):
     """Test if multiple virtual process data are requested."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{10,11}-pydantic{1,2}
+envlist = py3{9,10,11,12}-pydantic{1,2}
 
 [testenv]
 description = Executes pytest


### PR DESCRIPTION
According to #17, the code does not run with python 3.9. I updated tox to include 3.9 and also 3.12. I dropped 3.8 because it never worked and support for python will drop in October.

This PR contains code changes which makes it compatible with 3.9. Most of the changes fix the new typing syntax. In api.py the decorator for re-login has to be moved into a function instead a static method.