### PR TITLE
Fix API error with newer inverter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           pipenv install --dev --python ${{ matrix.python-version }}
       - name: Lint with ruff
         run: |
-          pipenv run ruff --output-format=github .
+          pipenv run ruff check --output-format=github .
       - name: Type check with mypy
         run: |
           pipenv run mypy pykoplenti/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+## Fixed
+
+- `get_settings_values` return an API 500 error incase the overload variant `(str, Iterable[str])`
+  was used on newer models (like Plenticore plus G2).
+
 ## [1.4.0] - 2025-04-01
 
 ### Changed

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -874,26 +874,29 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:30ad74687e1f4a9ff8e513b20b82ccadb6bd796fe5697f1e417189c5cde6be3e",
-                "sha256:3826fb34c144ef1e171b323ed6ae9146ab76d109960addca730756dc19dc7b22",
-                "sha256:3d3c641f95f435fc6754b05591774a17df41648f0daf3de0d75ad3d9f099ab92",
-                "sha256:3fbaff1ba9564a2c5943f8f38bc221f04bac687cc7485e45237579fee7ccda79",
-                "sha256:3ff35433fcf4dff6d610738712152df6b7d92351a1bde8e00bd405b08b3d5759",
-                "sha256:63856b91837606c673537d2889989733d7dffde553828d3b0f0bacfa6def54be",
-                "sha256:638ea3294f800d18bae84a492cb5a245c8d29c90d19a91d8e338937a4c27fca0",
-                "sha256:6d232f99d3ab00094ebaf88e0fb7a8ccacaa54cc7fa3b8993d9627a11e6aed7a",
-                "sha256:8153a3e4128ed770871c47545f1ae7b055023e0c222ff72a759f5a341ee06483",
-                "sha256:87057dd2fdde297130ff99553be8549ca38a2965871462a97394c22ed2dfc19d",
-                "sha256:a7e3818698f8460bd0f8d4322bbe99db8327e9bc2c93c789d3159f5b335f47da",
-                "sha256:ba918e01cdd21e81b07555564f40d307b0caafa9a7a65742e98ff244f5035c59",
-                "sha256:bf9faafbdcf4f53917019f2c230766da437d4fd5caecd12ddb68bb6a17d74399",
-                "sha256:e155147199c2714ff52385b760fe242bb99ea64b240a9ffbd6a5918eb1268843",
-                "sha256:e8a75a98ae989a27090e9c51f763990ad5bbc92d20626d54e9701c7fe597f399",
-                "sha256:eceab7d85d09321b4de18b62d38710cf296cb49e98979960a59c6b9307c18cfe",
-                "sha256:edf23041242c48b0d8295214783ef543847ef29e8226d9f69bf96592dba82a83"
+                "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6",
+                "sha256:1484983559f026788e3a5c07c81ef7d1e97c1c78ed03041a18f75df104c45405",
+                "sha256:16a01dfb7b9e4eee556fbfd5392806b1b8550c9b4a9f6acd3dbe6812b193c70a",
+                "sha256:213db2b2e44be8625002dbea33bb9c60c66ea2c07c084a00d55732689d697a7f",
+                "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154",
+                "sha256:4bb98fcbbc61725968893682fd4df8966a34611239c9fd07a1f6a07e7103d08e",
+                "sha256:59aabd2e2c4fd614d2862e7939c34a532c04f1084476d6833dddef4afab87e9f",
+                "sha256:5bcf45b681e9f1ee6445d317ce1fa9d6cba9a6049542d1c3d5b5958986be8830",
+                "sha256:674f9be9372907f7257c51f1d4fc902cb7cf014b9980152b802794317941f08f",
+                "sha256:6987ebe0501ae4f4308d7d24e2d0fe3d7a98430f5adfd0f1fead050a740a3a77",
+                "sha256:7165d31a925b7a294465fa81be8c12a0e9b60fb02bf177e79067c867e71f8b1f",
+                "sha256:7a3ce585f2ade3e1f29ec1b92df13e3da262178df8c8bdf876f48fa0e8316c49",
+                "sha256:9a2e830f075d1a42cd28420d7809ace390832a490ed0966fe373ba288e77aaf4",
+                "sha256:b914c40ab64865a17a9a5b67911d14df72346a634527240039eb3bd650e5979d",
+                "sha256:c561695675b972effb0c0a45db233f2c816ff3da8dcfbe7dfc7eed625f218935",
+                "sha256:c70427132db492d25f982fffc8d6c7535cc2fd2c83fc8888f05caaa248521e60",
+                "sha256:d85713d522348837ef9df8efca33ccb8bd6fcfc86a2cde3ccb4bc9d28a18003d",
+                "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6",
+                "sha256:f24b47993a9d8cb858429e97bdf8544c78029f09b520af615c1d261bf827001d"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.10"
         },
         "tomli": {
             "hashes": [

--- a/pykoplenti/api.py
+++ b/pykoplenti/api.py
@@ -665,6 +665,21 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
             async with self._session_request("settings", method="POST", json=request) as resp:
                 await self._check_response(resp)
                 data_response = await resp.json()
+                # expected response looks like
+                # [
+                #   {
+                #       "moduleid": <id>,
+                #       "settings":
+                #       [
+                #           {
+                #               "id": <id>,
+                #               "value": <value>
+                #           },
+                #        ...
+                #       ]
+                #   },
+                #  ...
+                # ]
                 return {
                     x["moduleid"]: {y["id"]: y["value"] for y in x["settings"]}
                     for x in data_response

--- a/pykoplenti/api.py
+++ b/pykoplenti/api.py
@@ -649,11 +649,26 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
             and hasattr(setting_id, "__iter__")
         ):
             # get multiple settings of a module
-            ids = ",".join(setting_id)
-            async with self._session_request(f"settings/{module_id}/{ids}") as resp:
+
+            # There was once an API version which explicitly supports a single module with
+            # multiple settings in one request. However this way seems to be not supported anymore
+            # and hence we use the same approach as for multiple modules.
+            # Known to work: Plenticore plus 10
+            # Known not to work: Plenticore plus 10 G2, Plenticore M G3
+            request = [
+                {
+                    "moduleid": module_id,
+                    "settingids": list(setting_id),
+                }
+            ]
+
+            async with self._session_request("settings", method="POST", json=request) as resp:
                 await self._check_response(resp)
                 data_response = await resp.json()
-                return {module_id: {x["id"]: x["value"] for x in data_response}}
+                return {
+                    x["moduleid"]: {y["id"]: y["value"] for y in x["settings"]}
+                    for x in data_response
+                }
 
         if isinstance(module_id, dict) and setting_id is None:
             # get multiple process data of multiple modules

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -95,7 +95,7 @@ class TestSmokeTests:
     async def test_smoketest_setting_value1(
         self, authenticated_client: pykoplenti.ApiClient
     ):
-        """Retrieves the setting value with variante 1."""
+        """Retrieves the setting value with variant (str, str)."""
 
         setting_value = await authenticated_client.get_setting_values(
             "devices:local", "Branding:ProductName1"
@@ -109,7 +109,7 @@ class TestSmokeTests:
     async def test_smoketest_setting_value2(
         self, authenticated_client: pykoplenti.ApiClient
     ):
-        """Retrieves the setting value with variante 2."""
+        """Retrieves the setting value with variant (str, Iterable[str])."""
 
         setting_value = await authenticated_client.get_setting_values(
             "devices:local", ["Branding:ProductName1"]
@@ -124,7 +124,7 @@ class TestSmokeTests:
     async def test_smoketest_setting_value3(
         self, authenticated_client: pykoplenti.ApiClient
     ):
-        """Retrieves the setting value with variante 3."""
+        """Retrieves the setting value with variant (str, None)."""
 
         setting_value = await authenticated_client.get_setting_values(
             "devices:local"
@@ -138,7 +138,7 @@ class TestSmokeTests:
     async def test_smoketest_setting_value4(
         self, authenticated_client: pykoplenti.ApiClient
     ):
-        """Retrieves the setting value with variante 4."""
+        """Retrieves the setting value with variant (Mapping[str, Iterable[str]])."""
 
         setting_value = await authenticated_client.get_setting_values(
             {"devices:local": ["Branding:ProductName1"]}


### PR DESCRIPTION
Some newer inverter seems to no longer support a specific method for getting multiple settings value of a single module. This PR replace this call by another method.

The following inverter seems to no longer support the removed API method:

- Plenticore plus 10 G2
- Plenticore M G3

## Summary by Sourcery

Update settings retrieval API to remain compatible with newer inverter models when requesting multiple settings for a single module.

Bug Fixes:
- Switch multi-setting retrieval for a single module to the generic POST /settings endpoint to restore compatibility with newer inverter firmware.

Build:
- Pin the ruff dev dependency to version ~=0.14.

Tests:
- Clarify smoketest docstrings to document the supported get_setting_values parameter variants.