### PR TITLE
Prepare release candiate for 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- `get_settings_values` return an API 500 error incase the overload variant `(str, Iterable[str])`
+- `get_settings_values` returns an API 500 error in case the overload variant `(str, Iterable[str])`
   was used on newer models (like Plenticore plus G2).
 
 ## Internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Next
+## [1.5.0] - 2026-01-07
 
 ## Fixed
 
 - `get_settings_values` return an API 500 error incase the overload variant `(str, Iterable[str])`
   was used on newer models (like Plenticore plus G2).
+
+## Internally
+
+- Migrate to uv from pipenv
 
 ## [1.4.0] - 2025-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2026-01-07
 
-## Fixed
+### Fixed
 
 - `get_settings_values` returns an API 500 error in case the overload variant `(str, Iterable[str])`
   was used on newer models (like Plenticore plus G2).
 
-## Internally
+### Internally
 
 - Migrate to uv from pipenv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pykoplenti"
-version = "1.4.0"
+version = "1.5.0rc1"
 description = "Python REST-Client for Kostal Plenticore Solar Inverters"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
prepare rc1 for 1.5.0

## Summary by Sourcery

Cut the 1.5.0 release candidate and document the included bug fix and internal tooling changes.

Bug Fixes:
- Document the fix for API 500 errors when calling `get_settings_values` with the `(str, Iterable[str])` overload on newer inverter models.

Enhancements:
- Document internal migration from pipenv to uv for dependency and environment management.

Build:
- Bump project version to 1.5.0rc1 in pyproject configuration.

Documentation:
- Update the changelog with a 1.5.0 release section including date and notable changes.