### PR TITLE
Fix get_process_data_values for multiple values of the same module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+
+- `get_process_data_values` returns an API 500 error in case the overload variant `(str, Iterable[str])`
+  was used on newer models (like Plenticore plus G2).
+
 ## [1.5.0] - 2026-01-07
 
 ### Fixed

--- a/pykoplenti/api.py
+++ b/pykoplenti/api.py
@@ -539,14 +539,20 @@ class ApiClient(contextlib.AbstractAsyncContextManager):
             and hasattr(processdata_id, "__iter__")
         ):
             # get multiple process data of a module
-            ids = ",".join(processdata_id)
-            async with self._session_request(f"processdata/{module_id}/{ids}") as resp:
+
+            request = [
+                {
+                    "moduleid": module_id,
+                    "processdataids": list(processdata_id),
+                }
+            ]
+
+            async with self._session_request("processdata", method="POST", json=request) as resp:
                 await self._check_response(resp)
                 data_response = await resp.json()
                 return {
-                    data_response[0]["moduleid"]: ProcessDataCollection(
-                        process_data_list(data_response[0]["processdata"])
-                    )
+                    x["moduleid"]: ProcessDataCollection(process_data_list(x["processdata"]))
+                    for x in data_response
                 }
 
         if isinstance(module_id, dict) and processdata_id is None:


### PR DESCRIPTION
This pull request updates the way multiple process data values are fetched for a module in the `get_process_data_values` method in `pykoplenti/api.py`. The main change is switching from a GET request with comma-separated IDs to a POST request with a structured JSON payload, improving compatibility with newer version of the inverter.

This PR address issue #24.

## Summary by Sourcery

Bug Fixes:
- Correct fetching of multiple process data values for a module by using the inverter's POST endpoint with a structured JSON payload.